### PR TITLE
Update defaults.clog_config

### DIFF
--- a/inc/defaults.clog_config
+++ b/inc/defaults.clog_config
@@ -11,90 +11,164 @@
         "DefinationEncoding": "!BYTEARRAY!"
       },
       {
-        "EncodingType": "UInt32",
-        "CType": "CLOG_INT32",
+        "EncodingType": "Int32",
+        "CType": "int",
         "DefinationEncoding": "d",
-        "CustomDecoder": "defaults.clog_config.Types.DecodeUInt32"
       },
       {
-        "EncodingType": "UInt8",
-        "CType": "CLOG_UINT8",
-        "DefinationEncoding": "hhu"
-      },
-      {
-        "EncodingType": "UInt16",
-        "CType": "unsigned short",
-        "DefinationEncoding": "hu"
-      },
-      {
-        "EncodingType": "UInt16",
-        "CType": "unsigned short",
-        "DefinationEncoding": "hd"
-      },
-      {
-        "EncodingType": "UInt16",
-        "CType": "unsigned short",
-        "DefinationEncoding": "hx"
-      },
-      {
-        "EncodingType": "UInt16",
-        "CType": "unsigned short",
-        "DefinationEncoding": "hX"
-      },
-      {
-        "EncodingType": "UInt8",
-        "CType": "CLOG_UINT8",
-        "DefinationEncoding": "c"
-      },
-      {
-        "EncodingType": "Int64",
-        "CType": "CLOG_INT64",
-        "DefinationEncoding": "ld"
-      },
-      {
-        "EncodingType": "UInt64",
-        "CType": "CLOG_UINT64",
-        "DefinationEncoding": "lu"
-      },
-      {
-        "EncodingType": "UInt64",
-        "CType": "CLOG_UINT64",
-        "DefinationEncoding": "llu"
-      },
-      {
-        "EncodingType": "UInt64",
-        "CType": "CLOG_UINT64",
-        "DefinationEncoding": "llx"
-      },
-      {
-        "EncodingType": "Int64",
-        "CType": "CLOG_INT64",
-        "DefinationEncoding": "lld"
-      },
-      {
-        "EncodingType": "UInt64",
-        "CType": "CLOG_UINT64",
-        "DefinationEncoding": "llX"
-      },
-      {
-        "EncodingType": "Int64",
-        "CType": "CLOG_INT64",
-        "DefinationEncoding": "zd"
+        "EncodingType": "Int8",
+        "CType": "signed char",
+        "DefinationEncoding": "hhd",
       },
       {
         "EncodingType": "Int32",
-        "CType": "CLOG_INT32",
-        "DefinationEncoding": "4.4x"
+        "CType": "long int",
+        "DefinationEncoding": "ld",
+      },
+      {
+        "EncodingType": "Int64",
+        "CType": "long long int",
+        "DefinationEncoding": "lld",
+      },
+      {
+        "EncodingType": "Int64",
+        "CType": "size_t",
+        "DefinationEncoding": "zd",
+      },
+      {
+        "EncodingType": "Int64",
+        "CType": "ptrdiff_t",
+        "DefinationEncoding": "td",
+      },
+      {
+        "EncodingType": "Int32",
+        "CType": "int",
+        "DefinationEncoding": "i",
+      },
+      {
+        "EncodingType": "Int8",
+        "CType": "signed char",
+        "DefinationEncoding": "hhi",
+      },
+      {
+        "EncodingType": "Int32",
+        "CType": "long int",
+        "DefinationEncoding": "li",
+      },
+      {
+        "EncodingType": "Int64",
+        "CType": "long long int",
+        "DefinationEncoding": "lli",
+      },
+      {
+        "EncodingType": "Int64",
+        "CType": "size_t",
+        "DefinationEncoding": "zi",
+      },
+      {
+        "EncodingType": "Int64",
+        "CType": "ptrdiff_t",
+        "DefinationEncoding": "ti",
       },
       {
         "EncodingType": "UInt32",
-        "CType": "CLOG_UINT32",
-        "DefinationEncoding": "u"
+        "CType": "unsigned int",
+        "DefinationEncoding": "u",
       },
       {
-        "EncodingType": "UNICODE_String",
-        "CType": "const unsigned short *",
-        "DefinationEncoding": "S"
+        "EncodingType": "UInt8",
+        "CType": "unsigned char",
+        "DefinationEncoding": "hhu",
+      },
+      {
+        "EncodingType": "UInt32",
+        "CType": "unsigned long int",
+        "DefinationEncoding": "lu",
+      },
+      {
+        "EncodingType": "UInt64",
+        "CType": "unsigned long long int",
+        "DefinationEncoding": "llu",
+      },
+      {
+        "EncodingType": "UInt64",
+        "CType": "size_t",
+        "DefinationEncoding": "zu",
+      },
+      {
+        "EncodingType": "UInt64",
+        "CType": "ptrdiff_t",
+        "DefinationEncoding": "tu",
+      },
+      {
+        "EncodingType": "UInt32",
+        "CType": "unsigned int",
+        "DefinationEncoding": "x",
+      },
+      {
+        "EncodingType": "UInt32",
+        "CType": "unsigned int",
+        "DefinationEncoding": "4.4x"
+      },
+      {
+        "EncodingType": "UInt8",
+        "CType": "unsigned char",
+        "DefinationEncoding": "hhx",
+      },
+      {
+        "EncodingType": "UInt32",
+        "CType": "unsigned long int",
+        "DefinationEncoding": "lx",
+      },
+      {
+        "EncodingType": "UInt64",
+        "CType": "unsigned long long int",
+        "DefinationEncoding": "llx",
+      },
+      {
+        "EncodingType": "UInt64",
+        "CType": "size_t",
+        "DefinationEncoding": "zx",
+      },
+      {
+        "EncodingType": "UInt64",
+        "CType": "ptrdiff_t",
+        "DefinationEncoding": "tx",
+      },
+      {
+        "EncodingType": "UInt32",
+        "CType": "unsigned int",
+        "DefinationEncoding": "X",
+      },
+      {
+        "EncodingType": "UInt8",
+        "CType": "unsigned char",
+        "DefinationEncoding": "hhX",
+      },
+      {
+        "EncodingType": "UInt32",
+        "CType": "unsigned long int",
+        "DefinationEncoding": "lX",
+      },
+      {
+        "EncodingType": "UInt64",
+        "CType": "unsigned long long int",
+        "DefinationEncoding": "llX",
+      },
+      {
+        "EncodingType": "UInt64",
+        "CType": "size_t",
+        "DefinationEncoding": "zX",
+      },
+      {
+        "EncodingType": "UInt64",
+        "CType": "ptrdiff_t",
+        "DefinationEncoding": "tX",
+      },
+      {
+        "EncodingType": "UInt8",
+        "CType": "char",
+        "DefinationEncoding": "c"
       },
       {
         "EncodingType": "ANSI_String",
@@ -102,15 +176,20 @@
         "DefinationEncoding": "s"
       },
       {
+        "EncodingType": "UNICODE_String",
+        "CType": "const wchar_t *",
+        "DefinationEncoding": "ls"
+      },
+      {
+        "EncodingType": "UNICODE_String",
+        "CType": "const wchar_t *",
+        "DefinationEncoding": "S"
+      },
+      {
         "EncodingType": "Pointer",
         "CType": "CLOG_PTR",
         "DefinationEncoding": "p",
         "CustomDecoder": "defaults.clog_config.Types.DecodePointer"
-      },
-      {
-        "EncodingType": "UInt32",
-        "CType": "CLOG_UINT32",
-        "DefinationEncoding": "x"
       }
     ]
   },


### PR DESCRIPTION
Adds support for many of the format specifiers from here: http://www.cplusplus.com/reference/cstdio/printf/

**Still to do:** There needs to be a way to dynamically support `flags`, `width` and `precision` format specifiers. For example:

`%8d` - the `8` specifies that a minimum of 8 characters are to be printed, padded with spaces.
`%08d` - the `08` specifies that a minimum of 8 characters are to be printed, padded with zeros.