### PR TITLE
Configure each usage of CLOG_ADD_SOURCEFILE to use its own output directory

### DIFF
--- a/inc/CLog.make
+++ b/inc/CLog.make
@@ -10,43 +10,43 @@ function(CLOG_ADD_SOURCEFILE)
      # message(STATUS ">>>> CLOG Library = ${library}")
      # message(STATUS ">>>> CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
 
+    add_custom_command(
+        WORKING_DIRECTORY ${CLOG_SOURCE_DIRECTORY}
+        COMMENT "Building CLOG and its support tooling"
+        COMMENT "dotnet build ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_coreclr.sln -o ${CMAKE_CLOG_BINS_DIRECTORY}/${library}"
+        OUTPUT ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/clog.dll
+        COMMAND dotnet build ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_coreclr.sln -o ${CMAKE_CLOG_BINS_DIRECTORY}/${library}
+    )
+
+    add_custom_command(
+        WORKING_DIRECTORY ${CLOG_SOURCE_DIRECTORY}
+        COMMENT "Building CLOG and its support tooling"
+        COMMENT "msbuild -t:restore ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_windows.sln"
+        COMMENT "msbuild ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_windows.sln /p:OutDir=${CMAKE_CLOG_BINS_DIRECTORY}/${library}/windows"
+        OUTPUT ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/windows/clog2text_windows.exe
+        COMMAND msbuild -t:restore ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog.sln
+        COMMAND msbuild ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog.sln /p:OutDir=${CMAKE_CLOG_BINS_DIRECTORY}/${library}/windows
+    )
+
     foreach(arg IN LISTS ARGV)
         get_filename_component(RAW_FILENAME ${arg} NAME)
-        set(ARG_CLOG_FILE ${CMAKE_CLOG_OUTPUT_DIRECTORY}/${RAW_FILENAME}.clog.h)
-        set(ARG_CLOG_C_FILE ${CMAKE_CLOG_OUTPUT_DIRECTORY}/${library}_${RAW_FILENAME}.clog.h.c)
+        set(ARG_CLOG_FILE ${CMAKE_CLOG_OUTPUT_DIRECTORY}/${library}/${RAW_FILENAME}.clog.h)
+        set(ARG_CLOG_C_FILE ${CMAKE_CLOG_OUTPUT_DIRECTORY}/${library}/${library}_${RAW_FILENAME}.clog.h.c)
 
         # message(STATUS ">>>>>>> CLOG Source File = ${RAW_FILENAME}")
 
-        add_custom_command(
-            WORKING_DIRECTORY ${CLOG_SOURCE_DIRECTORY}
-            COMMENT "Building CLOG and its support tooling"
-            COMMENT "dotnet build ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_coreclr.sln -o ${CMAKE_CLOG_BINS_DIRECTORY}"
-            OUTPUT ${CMAKE_CLOG_BINS_DIRECTORY}/clog.dll
-            COMMAND dotnet build ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_coreclr.sln -o ${CMAKE_CLOG_BINS_DIRECTORY}
-        )
-
-        add_custom_command(
-            WORKING_DIRECTORY ${CLOG_SOURCE_DIRECTORY}
-            COMMENT "Building CLOG and its support tooling"
-            COMMENT "msbuild -t:restore ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_windows.sln"
-            COMMENT "msbuild ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_windows.sln /p:OutDir=${CMAKE_CLOG_BINS_DIRECTORY}/windows"
-            OUTPUT ${CMAKE_CLOG_BINS_DIRECTORY}/windows/clog2text_windows.exe
-            COMMAND msbuild -t:restore ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog.sln
-            COMMAND msbuild ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog.sln /p:OutDir=${CMAKE_CLOG_BINS_DIRECTORY}/windows
-        )
-
         if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
             set_property(SOURCE ${arg}
-                APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CLOG_BINS_DIRECTORY}/windows/clog2text_windows.exe
+                APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/windows/clog2text_windows.exe
             )
         endif()
 
         add_custom_command(
             OUTPUT ${ARG_CLOG_FILE} ${ARG_CLOG_C_FILE}
-            DEPENDS ${CMAKE_CLOG_BINS_DIRECTORY}/clog.dll
+            DEPENDS ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/clog.dll
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${arg}
-            COMMENT "CLOG: ${CMAKE_CLOG_BINS_DIRECTORY}/clog --readOnly -p ${CMAKE_CLOG_CONFIG_PROFILE} --scopePrefix ${library} -c ${CMAKE_CLOG_CONFIG_FILE} -s ${CMAKE_CLOG_SIDECAR_DIRECTORY}/clog.sidecar -i ${CMAKE_CURRENT_SOURCE_DIR}/${arg} -o ${ARG_CLOG_FILE}"
-            COMMAND ${CMAKE_CLOG_BINS_DIRECTORY}/clog --readOnly -p ${CMAKE_CLOG_CONFIG_PROFILE} --scopePrefix ${library} -c ${CMAKE_CLOG_CONFIG_FILE} -s ${CMAKE_CLOG_SIDECAR_DIRECTORY}/clog.sidecar -i ${CMAKE_CURRENT_SOURCE_DIR}/${arg} -o ${ARG_CLOG_FILE}
+            COMMENT "CLOG: ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/clog --readOnly -p ${CMAKE_CLOG_CONFIG_PROFILE} --scopePrefix ${library} -c ${CMAKE_CLOG_CONFIG_FILE} -s ${CMAKE_CLOG_SIDECAR_DIRECTORY}/clog.sidecar -i ${CMAKE_CURRENT_SOURCE_DIR}/${arg} -o ${ARG_CLOG_FILE}"
+            COMMAND ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/clog --readOnly -p ${CMAKE_CLOG_CONFIG_PROFILE} --scopePrefix ${library} -c ${CMAKE_CLOG_CONFIG_FILE} -s ${CMAKE_CLOG_SIDECAR_DIRECTORY}/clog.sidecar -i ${CMAKE_CURRENT_SOURCE_DIR}/${arg} -o ${ARG_CLOG_FILE}
         )
 
         set_property(TARGET CLOG_GENERATED_FILES
@@ -61,6 +61,7 @@ function(CLOG_ADD_SOURCEFILE)
         list(APPEND clogfiles ${ARG_CLOG_C_FILE})
     endforeach()
 
-    add_library(${library} STATIC ${clogfiles})	
+    add_library(${library} STATIC ${clogfiles})
+    target_include_directories(${library} PUBLIC ${CMAKE_CLOG_OUTPUT_DIRECTORY}/${library})
     # message(STATUS "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
 endfunction()


### PR DESCRIPTION
Previously, the outputs from the dotnet command, along with the header generation, would all output to the same directory no matter how many times CLOG_ADD_SOURCEFILE was called. This caused multiple issues. First, many build systems (such as ninja) fail if the same custom command outputs to the same file. It breaks their output tracking. Secondly, if 2 projects were built, both with an identically named source file (such as main.cpp), it would be a race to see which file would actually get its clog file generated, because 2 files with the same name would be generated into the same directory.

This solves both of those issues by making each invoke of the dotnet commands output to their own subdirectory of CLOG_BINS_DIRECTORY. In addition, the header outputs are now generated into their own subdirectory of CLOG_INCLUDE_DIRECTORY. To then fix includes, target_include_directories is used on the library target to include the correct subdirectories. This is more correct anyway, as now the include dirs propogate through the target