### PR TITLE
Refactor CMake build to use a high level submodule for CLOG exe build

### DIFF
--- a/examples/clogsample/CMakeLists.txt
+++ b/examples/clogsample/CMakeLists.txt
@@ -1,31 +1,21 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-#
-#
-# BUGBUG : these may not be required
-#
-#
-add_custom_target(CLOG_GENERATED_FILES
-    COMMENT "CREATED CMAKE Target for CLOG generated files"
-)
+# Add clog subdirectory inc folder to create CLOG target
+add_subdirectory(submodules/clog/inc)
 
 # Include Files that need CLOG processing
 include("${CLOG_INCLUDE_DIRECTORY}/CLog.make")
-include_directories(${CMAKE_CLOG_OUTPUT_DIRECTORY})
 
 set(SOURCES
     simple.cpp
 )
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${QUIC_C_FLAGS}")
-
 #
-# Setup CLOG by calling a helper function which sets up dependencies.  Then add the .c file
-#     ...it'd be preferred to have the helper function set this requirement
+# Create a clog target for all the source files. This target is then used
+# as a normal cmake target dependency
 #
-CLOG_ADD_SOURCEFILE(CLOGSAMPLE_LIB ${SOURCES})
+CLOG_GENERATE_TARGET(CLOGSAMPLE_LIB ${SOURCES})
 
 add_executable (clogsample ${SOURCES})
-add_dependencies(clogsample CLOGSAMPLE_LIB)
 target_link_libraries(clogsample CLOGSAMPLE_LIB)

--- a/inc/CLog.make
+++ b/inc/CLog.make
@@ -1,4 +1,11 @@
-function(CLOG_ADD_SOURCEFILE)
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Creates a target to build all generated clog files of the input
+# sources
+#
+function(CLOG_GENERATE_TARGET)
     set(library ${ARGV0})
     list(REMOVE_AT ARGV 0)
      # message(STATUS "****************<<<<<<<   CLOG(${library}))    >>>>>>>>>>>>>>>*******************")
@@ -10,24 +17,6 @@ function(CLOG_ADD_SOURCEFILE)
      # message(STATUS ">>>> CLOG Library = ${library}")
      # message(STATUS ">>>> CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
 
-    add_custom_command(
-        WORKING_DIRECTORY ${CLOG_SOURCE_DIRECTORY}
-        COMMENT "Building CLOG and its support tooling"
-        COMMENT "dotnet build ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_coreclr.sln -o ${CMAKE_CLOG_BINS_DIRECTORY}/${library}"
-        OUTPUT ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/clog.dll
-        COMMAND dotnet build ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_coreclr.sln -o ${CMAKE_CLOG_BINS_DIRECTORY}/${library}
-    )
-
-    add_custom_command(
-        WORKING_DIRECTORY ${CLOG_SOURCE_DIRECTORY}
-        COMMENT "Building CLOG and its support tooling"
-        COMMENT "msbuild -t:restore ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_windows.sln"
-        COMMENT "msbuild ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_windows.sln /p:OutDir=${CMAKE_CLOG_BINS_DIRECTORY}/${library}/windows"
-        OUTPUT ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/windows/clog2text_windows.exe
-        COMMAND msbuild -t:restore ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog.sln
-        COMMAND msbuild ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog.sln /p:OutDir=${CMAKE_CLOG_BINS_DIRECTORY}/${library}/windows
-    )
-
     foreach(arg IN LISTS ARGV)
         get_filename_component(RAW_FILENAME ${arg} NAME)
         set(ARG_CLOG_FILE ${CMAKE_CLOG_OUTPUT_DIRECTORY}/${library}/${RAW_FILENAME}.clog.h)
@@ -35,23 +24,12 @@ function(CLOG_ADD_SOURCEFILE)
 
         # message(STATUS ">>>>>>> CLOG Source File = ${RAW_FILENAME}")
 
-        if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-            set_property(SOURCE ${arg}
-                APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/windows/clog2text_windows.exe
-            )
-        endif()
-
         add_custom_command(
             OUTPUT ${ARG_CLOG_FILE} ${ARG_CLOG_C_FILE}
-            DEPENDS ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/clog.dll
+            DEPENDS CLOG
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${arg}
-            COMMENT "CLOG: ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/clog --readOnly -p ${CMAKE_CLOG_CONFIG_PROFILE} --scopePrefix ${library} -c ${CMAKE_CLOG_CONFIG_FILE} -s ${CMAKE_CLOG_SIDECAR_DIRECTORY}/clog.sidecar -i ${CMAKE_CURRENT_SOURCE_DIR}/${arg} -o ${ARG_CLOG_FILE}"
-            COMMAND ${CMAKE_CLOG_BINS_DIRECTORY}/${library}/clog --readOnly -p ${CMAKE_CLOG_CONFIG_PROFILE} --scopePrefix ${library} -c ${CMAKE_CLOG_CONFIG_FILE} -s ${CMAKE_CLOG_SIDECAR_DIRECTORY}/clog.sidecar -i ${CMAKE_CURRENT_SOURCE_DIR}/${arg} -o ${ARG_CLOG_FILE}
-        )
-
-        set_property(TARGET CLOG_GENERATED_FILES
-            APPEND PROPERTY OBJECT_DEPENDS ${ARG_CLOG_FILE}
-            APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${arg}
+            COMMENT "CLOG: ${CMAKE_CLOG_BINS_DIRECTORY}/clog --readOnly -p ${CMAKE_CLOG_CONFIG_PROFILE} --scopePrefix ${library} -c ${CMAKE_CLOG_CONFIG_FILE} -s ${CMAKE_CLOG_SIDECAR_DIRECTORY}/clog.sidecar -i ${CMAKE_CURRENT_SOURCE_DIR}/${arg} -o ${ARG_CLOG_FILE}"
+            COMMAND ${CMAKE_CLOG_BINS_DIRECTORY}/clog --readOnly -p ${CMAKE_CLOG_CONFIG_PROFILE} --scopePrefix ${library} -c ${CMAKE_CLOG_CONFIG_FILE} -s ${CMAKE_CLOG_SIDECAR_DIRECTORY}/clog.sidecar -i ${CMAKE_CURRENT_SOURCE_DIR}/${arg} -o ${ARG_CLOG_FILE}
         )
 
         set_property(SOURCE ${arg}

--- a/inc/CLog.make
+++ b/inc/CLog.make
@@ -62,6 +62,7 @@ function(CLOG_ADD_SOURCEFILE)
     endforeach()
 
     add_library(${library} STATIC ${clogfiles})
+    target_include_directories(${library} PRIVATE ${CLOG_INCLUDE_DIRECTORY})
     target_include_directories(${library} PUBLIC ${CMAKE_CLOG_OUTPUT_DIRECTORY}/${library})
     # message(STATUS "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
 endfunction()

--- a/inc/CMakeLists.txt
+++ b/inc/CMakeLists.txt
@@ -9,8 +9,6 @@ add_custom_command(
     COMMAND dotnet build ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_coreclr.sln -o ${CMAKE_CLOG_BINS_DIRECTORY}
 )
 
-
-
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     add_custom_command(
         WORKING_DIRECTORY ${CLOG_SOURCE_DIRECTORY}

--- a/inc/CMakeLists.txt
+++ b/inc/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+add_custom_command(
+    WORKING_DIRECTORY ${CLOG_SOURCE_DIRECTORY}
+    COMMENT "Building CLOG and its support tooling"
+    COMMENT "dotnet build ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_coreclr.sln -o ${CMAKE_CLOG_BINS_DIRECTORY}"
+    OUTPUT ${CMAKE_CLOG_BINS_DIRECTORY}/clog.dll
+    COMMAND dotnet build ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_coreclr.sln -o ${CMAKE_CLOG_BINS_DIRECTORY}
+)
+
+
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    add_custom_command(
+        WORKING_DIRECTORY ${CLOG_SOURCE_DIRECTORY}
+        COMMENT "Building CLOG and its support tooling"
+        COMMENT "msbuild -t:restore ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_windows.sln"
+        COMMENT "msbuild ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog_windows.sln /p:OutDir=${CMAKE_CLOG_BINS_DIRECTORY}/windows"
+        OUTPUT ${CMAKE_CLOG_BINS_DIRECTORY}/windows/clog2text_windows.exe
+        COMMAND msbuild -t:restore ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog.sln
+        COMMAND msbuild ${CLOG_SOURCE_DIRECTORY}/clog.sln/clog.sln /p:OutDir=${CMAKE_CLOG_BINS_DIRECTORY}/windows
+    )
+
+    add_custom_target(
+        CLOG
+        DEPENDS ${CMAKE_CLOG_BINS_DIRECTORY}/clog.dll
+        DEPENDS ${CMAKE_CLOG_BINS_DIRECTORY}/windows/clog2text_windows.exe
+    )
+
+else()
+    add_custom_target(
+        CLOG
+        DEPENDS ${CMAKE_CLOG_BINS_DIRECTORY}/clog.dll
+    )
+endif()


### PR DESCRIPTION
The existing method of using a function to generate all the clog files for a specific set of sources had some issues. First, because of how dependencies work, each instance of that function being called cause the clog build to occur into its own directory, increasing build times needlessly. In addition, this made tracking dependencies difficult, especially in the case when clog2text_windows was necessary. This change does 4 things:

1. Move CLOG executable build to its own CMake subproject. This is just added as a normal subdirectory by users, and creates the `CLOG` target that can be used as an easy dependency by downstream projects.

2. Rename `CLOG_ADD_SOURCEFILE` to `CLOG_GENERATE_TARGET`. This is a little bit clearer about what happens.

3. Updates `CLOG_GENERATE_TARGET` to use the new `CLOG` target. This also involves making the local include directory a private dependency of the CLOG target. 

4. Remove the unnecessary CLOG_GENERATED_FILES, its not useful, and just adds complication to users.