### PR TITLE
Update to netcoreapp3.1

### DIFF
--- a/clog/clog.csproj
+++ b/clog/clog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/clog2text/clog2text_lttng/clog2text_lttng.csproj
+++ b/clog2text/clog2text_lttng/clog2text_lttng.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/clog2text/clog2text_windows/clog2text_windows.csproj
+++ b/clog2text/clog2text_windows/clog2text_windows.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
netcoreapp3.0 is no longer supported, which might be why we can't run the app on linux on Azure.

Does not update the version, so we'll likely just replace the release.