### PR TITLE
Make clog headers only included in the target when building

### DIFF
--- a/defaults/CLog.cmake
+++ b/defaults/CLog.cmake
@@ -42,8 +42,8 @@ function(CLOG_GENERATE_TARGET)
         add_library(${library} SHARED ${clogfiles})
     endif()
 
-    target_include_directories(${library} PUBLIC ${CLOG_INCLUDE_DIRECTORY})
-    target_include_directories(${library} PUBLIC ${CMAKE_CLOG_OUTPUT_DIRECTORY}/${library})
+    target_include_directories(${library} PUBLIC $<BUILD_INTERFACE:${CLOG_INCLUDE_DIRECTORY}>)
+    target_include_directories(${library} PUBLIC $<BUILD_INTERFACE:${CMAKE_CLOG_OUTPUT_DIRECTORY}/${library}>)
 
     # message(STATUS "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
 endfunction()


### PR DESCRIPTION
When installing, we just need the DSO on unix platforms, and can ignore them on install. On windows, the target will never be installed anyway.

And hopefully, we have a solution at some point to this anyway