### PR TITLE
Properly test compile custom decoder when sidecar is actually saved

### DIFF
--- a/src/clogutils/ConfigFile/CLogConfigurationFile.cs
+++ b/src/clogutils/ConfigFile/CLogConfigurationFile.cs
@@ -491,9 +491,9 @@ namespace clogutils.ConfigFile
 
         public void ForceDecoderCompile() 
         {
-            if (CustomTypeClogCSharpFileContents != null)
+            if (TypeEncoders.CustomTypeDecoder != null)
             {
-                this.TypeEncoders.ForceDecoderCompile(CustomTypeClogCSharpFileContents);
+                this.TypeEncoders.ForceDecoderCompile(TypeEncoders.CustomTypeDecoder);
             }
             foreach (var config in ChainedConfigurations)
             {


### PR DESCRIPTION
Before was using the wrong variable, which doesn't work in all cases.

We still need dependency checking on the decoder to ensure the sidecar is marked dirty if the decoder is changed