### PR TITLE
Embed clog version in header

### DIFF
--- a/defaults/clog.h
+++ b/defaults/clog.h
@@ -7,6 +7,9 @@ Abstract:
 
     Main CLOG header file - this describes the primary macros that result in calling your desired trace libraries
 
+Version:
+    0.1.7
+
 --*/
 
 #pragma once


### PR DESCRIPTION
This way if a new clog version is used, all the generated files will be marked out of date because the header will have changed. Even if only internals of clog have changed