### PR TITLE
Add temporary workaround for out of date config files

### DIFF
--- a/defaults/clog.h
+++ b/defaults/clog.h
@@ -8,7 +8,7 @@ Abstract:
     Main CLOG header file - this describes the primary macros that result in calling your desired trace libraries
 
 Version:
-    0.1.7
+    0.1.8
 
 --*/
 

--- a/src/clog/clog.cs
+++ b/src/clog/clog.cs
@@ -173,8 +173,9 @@ namespace clog
                             if (null == sidecar)
                                 sidecar = new CLogSidecar();
                         }
-                        sidecar.ConfigFile = configFile;
 
+                        // Check for outdated config file
+                        sidecar.UpdateConfigFile(configFile);
 
                         if (options.RefreshCustomTypeProcessor)
                         {

--- a/src/clog/clog.csproj
+++ b/src/clog/clog.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.1.7</Version>
+    <Version>0.1.8</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>../nupkg</PackageOutputPath>

--- a/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
+++ b/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.1.7</Version>
+    <Version>0.1.8</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>../../nupkg</PackageOutputPath>

--- a/src/clog2text/clog2text_windows/clog2text_windows.csproj
+++ b/src/clog2text/clog2text_windows/clog2text_windows.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.1.7</Version>
+    <Version>0.1.8</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>../../nupkg</PackageOutputPath>

--- a/src/clogutils/CLogSidecar.cs
+++ b/src/clogutils/CLogSidecar.cs
@@ -57,6 +57,34 @@ namespace clogutils
             set;
         } = new CLogModuleUsageInformation();
 
+        public void UpdateConfigFile(CLogConfigurationFile newConfigFile)
+        {
+            // Ideally, we'd use CLogConfigurationFile.AreWeDirty, but because of the tricks
+            // we do around serialization, we can't without a major refactor
+
+            // Serialize old config
+            bool old = ConfigFile.SerializeChainedConfigurations;
+            ConfigFile.SerializeChainedConfigurations = true;
+
+            string serializedOldConfig = JsonConvert.SerializeObject(ConfigFile);
+
+            ConfigFile.SerializeChainedConfigurations = old;
+
+            // Serialize new config
+            old = newConfigFile.SerializeChainedConfigurations;
+            newConfigFile.SerializeChainedConfigurations = true;
+
+            string serializedNewConfig = JsonConvert.SerializeObject(newConfigFile);
+
+            newConfigFile.SerializeChainedConfigurations = old;
+
+            if (serializedOldConfig != serializedNewConfig)
+            {
+                AreDirty = true;
+                ChangesList.Add("Configuration file or dependencies changed");
+            }
+            ConfigFile = newConfigFile;
+        }
 
         private List<string> ChangesList = new List<string>();
         public void PrintDirtyReasons()

--- a/src/clogutils/CLogSidecar.cs
+++ b/src/clogutils/CLogSidecar.cs
@@ -62,6 +62,13 @@ namespace clogutils
             // Ideally, we'd use CLogConfigurationFile.AreWeDirty, but because of the tricks
             // we do around serialization, we can't without a major refactor
 
+            if (newConfigFile == null || ConfigFile == null) 
+            {
+                AreDirty = true;
+                ConfigFile = newConfigFile;
+                return;
+            }
+
             // Serialize old config
             bool old = ConfigFile.SerializeChainedConfigurations;
             ConfigFile.SerializeChainedConfigurations = true;

--- a/src/clogutils/ConfigFile/CLogConfigurationFile.cs
+++ b/src/clogutils/ConfigFile/CLogConfigurationFile.cs
@@ -180,6 +180,7 @@ namespace clogutils.ConfigFile
             set;
         } = new CLogTypeEncoder();
 
+        // TODO Actually make this set, including when the decoder files change
         public bool AmIDirty
         {
             get;


### PR DESCRIPTION
It involves just serializing both old and new configuration files, and seeing if theyre equal