### PR TITLE
Remove VariableInfo from being stored in the sidecar

### DIFF
--- a/defaults/clog.h
+++ b/defaults/clog.h
@@ -8,7 +8,7 @@ Abstract:
     Main CLOG header file - this describes the primary macros that result in calling your desired trace libraries
 
 Version:
-    0.1.9
+    0.2.0
 
 --*/
 

--- a/src/clog/TraceEmitterModules/CLogDTraceOutputModule.cs
+++ b/src/clog/TraceEmitterModules/CLogDTraceOutputModule.cs
@@ -89,7 +89,7 @@ namespace clog.TraceEmitterModules
                     //   length with the variable name <suggestedName>_len
                     if (CLogEncodingType.ByteArray == v.EncodingType)
                     {
-                        argsString += $"{seperatorB} unsigned int {arg.VariableInfo.SuggestedTelemetryName}_len{seperatorA}";
+                        argsString += $"{seperatorB} unsigned int {arg.MacroVariableName}_len{seperatorA}";
                         macroString += $"{seperatorB} {arg.MacroVariableName}_len{seperatorA}";
                     }
 

--- a/src/clog/TraceEmitterModules/CLogLTTNGOutputModule.cs
+++ b/src/clog/TraceEmitterModules/CLogLTTNGOutputModule.cs
@@ -153,7 +153,7 @@ namespace clog.TraceEmitterModules
 
             foreach (var arg in decodedTraceLine.splitArgs)
             {
-                lttngFile.AppendLine($"// {arg.MacroVariableName} = {arg.VariableInfo.SuggestedTelemetryName} = {arg.VariableInfo.UserSuppliedTrimmed}");
+                lttngFile.AppendLine($"// {arg.MacroVariableName} = {arg.MacroVariableName} = {arg.UserSuppliedTrimmed}");
             }
             lttngFile.AppendLine("----------------------------------------------------------*/");
 
@@ -185,23 +185,23 @@ namespace clog.TraceEmitterModules
                     {
                         lttngFile.Append(",");
                         lttngFile.AppendLine("");
-                        lttngFile.Append($"        unsigned int, {arg.VariableInfo.SuggestedTelemetryName}_len");
+                        lttngFile.Append($"        unsigned int, {arg.MacroVariableName}_len");
                     }
 
                     lttngFile.Append(",");
                     lttngFile.AppendLine("");
-                    lttngFile.Append($"        {ConvertToClogType(node)}, {arg.VariableInfo.SuggestedTelemetryName}");
+                    lttngFile.Append($"        {ConvertToClogType(node)}, {arg.MacroVariableName}");
                 }
                 else
                 {
                     if (CLogEncodingType.ByteArray == node.EncodingType)
                     {
-                        lttngFile.Append($"        unsigned int, {arg.VariableInfo.SuggestedTelemetryName}_len");
+                        lttngFile.Append($"        unsigned int, {arg.MacroVariableName}_len");
                         lttngFile.Append(",");
                         lttngFile.AppendLine("");
                     }
 
-                    lttngFile.Append($"        {ConvertToClogType(node)}, {arg.VariableInfo.SuggestedTelemetryName}");
+                    lttngFile.Append($"        {ConvertToClogType(node)}, {arg.MacroVariableName}");
                 }
 
                 ++argNum;
@@ -230,61 +230,61 @@ namespace clog.TraceEmitterModules
 
                     case CLogEncodingType.ByteArray:
                         lttngFile.AppendLine(
-                            $"        ctf_integer(unsigned int, {arg.VariableInfo.SuggestedTelemetryName}_len, {arg.VariableInfo.SuggestedTelemetryName}_len)");
+                            $"        ctf_integer(unsigned int, {arg.MacroVariableName}_len, {arg.MacroVariableName}_len)");
 
                         lttngFile.AppendLine(
-                            $"        ctf_sequence(char, {arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName}, unsigned int, {arg.VariableInfo.SuggestedTelemetryName}_len)");
+                            $"        ctf_sequence(char, {arg.MacroVariableName}, {arg.MacroVariableName}, unsigned int, {arg.MacroVariableName}_len)");
                         break;
 
                     case CLogEncodingType.Int8:
                         lttngFile.AppendLine(
-                            $"        ctf_integer(char, {arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName})");
+                            $"        ctf_integer(char, {arg.MacroVariableName}, {arg.MacroVariableName})");
                         break;
 
                     case CLogEncodingType.UInt8:
                         lttngFile.AppendLine(
-                            $"        ctf_integer(unsigned char, {arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName})");
+                            $"        ctf_integer(unsigned char, {arg.MacroVariableName}, {arg.MacroVariableName})");
                         break;
 
 
                     case CLogEncodingType.Int16:
                         lttngFile.AppendLine(
-                            $"        ctf_integer(short, {arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName})");
+                            $"        ctf_integer(short, {arg.MacroVariableName}, {arg.MacroVariableName})");
                         break;
 
                     case CLogEncodingType.UInt16:
                         lttngFile.AppendLine(
-                            $"        ctf_integer(unsigned short, {arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName})");
+                            $"        ctf_integer(unsigned short, {arg.MacroVariableName}, {arg.MacroVariableName})");
                         break;
 
                     case CLogEncodingType.Int32:
                         lttngFile.AppendLine(
-                            $"        ctf_integer(int, {arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName})");
+                            $"        ctf_integer(int, {arg.MacroVariableName}, {arg.MacroVariableName})");
                         break;
 
                     case CLogEncodingType.UInt32:
                         lttngFile.AppendLine(
-                            $"        ctf_integer(unsigned int, {arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName})");
+                            $"        ctf_integer(unsigned int, {arg.MacroVariableName}, {arg.MacroVariableName})");
                         break;
 
                     case CLogEncodingType.Int64:
                         lttngFile.AppendLine(
-                            $"        ctf_integer(int64_t, {arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName})");
+                            $"        ctf_integer(int64_t, {arg.MacroVariableName}, {arg.MacroVariableName})");
                         break;
 
                     case CLogEncodingType.UInt64:
                         lttngFile.AppendLine(
-                            $"        ctf_integer(uint64_t, {arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName})");
+                            $"        ctf_integer(uint64_t, {arg.MacroVariableName}, {arg.MacroVariableName})");
                         break;
 
                     case CLogEncodingType.Pointer:
                         lttngFile.AppendLine(
-                            $"        ctf_integer_hex(uint64_t, {arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName})");
+                            $"        ctf_integer_hex(uint64_t, {arg.MacroVariableName}, {arg.MacroVariableName})");
                         break;
 
                     case CLogEncodingType.ANSI_String:
                         lttngFile.AppendLine(
-                            $"        ctf_string({arg.VariableInfo.SuggestedTelemetryName}, {arg.VariableInfo.SuggestedTelemetryName})");
+                            $"        ctf_string({arg.MacroVariableName}, {arg.MacroVariableName})");
                         break;
 
                     default:

--- a/src/clog/TraceEmitterModules/CLogManifestedETWOutputModule.cs
+++ b/src/clog/TraceEmitterModules/CLogManifestedETWOutputModule.cs
@@ -384,7 +384,7 @@ namespace clog.TraceEmitterModules
                 CLogEncodingCLogTypeSearch node = traceLine.configFile.FindType(arg, traceLine);
                 TemplateNode templateNode = new TemplateNode();
                 templateNode.ArgBundle = a2;
-                templateNode.Name = a2.VariableInfo.SuggestedTelemetryName;
+                templateNode.Name = a2.MacroVariableName;
 
                 switch (node.EncodingType)
                 {
@@ -458,8 +458,8 @@ namespace clog.TraceEmitterModules
 
                             templateNode = new TemplateNode();
                             templateNode.ArgBundle = a2;
-                            templateNode.Name = a2.VariableInfo.SuggestedTelemetryName;
-                            templateNode.LengthOfSelf = arg.VariableInfo.SuggestedTelemetryName + "_len";
+                            templateNode.Name = a2.MacroVariableName;
+                            templateNode.LengthOfSelf = arg.MacroVariableName + "_len";
                             templateNode.Type = "win:Binary";
                             templateNode.Hash = "binary_";
                         }
@@ -603,7 +603,7 @@ namespace clog.TraceEmitterModules
 
                 TemplateNode templateReference = listofArgsAsSpecifiedBySourceFile[argIdx];
 
-                argLookup[templateReference.ArgBundle.VariableInfo.SuggestedTelemetryName] = name;
+                argLookup[templateReference.ArgBundle.MacroVariableName] = name;
 
                 if (templateReference.Type != inType)
                 {

--- a/src/clog/TraceEmitterModules/CLogSystemTapModule.cs
+++ b/src/clog/TraceEmitterModules/CLogSystemTapModule.cs
@@ -107,7 +107,7 @@ namespace clog.TraceEmitterModules
                     //   length with the variable name <suggestedName>_len
                     if (CLogEncodingType.ByteArray == v.EncodingType)
                     {
-                        argsString += $"{seperatorB} unsigned int {arg.VariableInfo.SuggestedTelemetryName}_len{seperatorA}";
+                        argsString += $"{seperatorB} unsigned int {arg.MacroVariableName}_len{seperatorA}";
                         macroString += $"{seperatorB} {arg.MacroVariableName}_len{seperatorA}";
                     }
 

--- a/src/clog/TraceEmitterModules/CLogTraceLoggingOutputModule.cs
+++ b/src/clog/TraceEmitterModules/CLogTraceLoggingOutputModule.cs
@@ -82,51 +82,51 @@ namespace clog.TraceEmitterModules
                 switch (node.EncodingType)
                 {
                     case CLogEncodingType.Int8:
-                        traceloggingLine += ",\\\n    TraceLoggingInt8" + $"({arg.MacroVariableName},\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingInt8" + $"({arg.MacroVariableName},\"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.UInt8:
-                        traceloggingLine += ",\\\n    TraceLoggingUInt8" + $"({arg.MacroVariableName},\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingUInt8" + $"({arg.MacroVariableName},\"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.Int16:
-                        traceloggingLine += ",\\\n    TraceLoggingInt16" + $"({arg.MacroVariableName},\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingInt16" + $"({arg.MacroVariableName},\"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.UInt16:
-                        traceloggingLine += ",\\\n    TraceLoggingUInt16" + $"({arg.MacroVariableName},\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingUInt16" + $"({arg.MacroVariableName},\"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.Int32:
-                        traceloggingLine += ",\\\n    TraceLoggingInt32" + $"({arg.MacroVariableName},\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingInt32" + $"({arg.MacroVariableName},\"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.UInt32:
-                        traceloggingLine += ",\\\n    TraceLoggingUInt32" + $"({arg.MacroVariableName},\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingUInt32" + $"({arg.MacroVariableName},\"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.Int64:
-                        traceloggingLine += ",\\\n    TraceLoggingInt64" + $"({arg.MacroVariableName},\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingInt64" + $"({arg.MacroVariableName},\"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.UInt64:
-                        traceloggingLine += ",\\\n    TraceLoggingUInt64" + $"({arg.MacroVariableName},\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingUInt64" + $"({arg.MacroVariableName},\"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.Pointer:
-                        traceloggingLine += ",\\\n    TraceLoggingPointer" + $"({arg.MacroVariableName},\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingPointer" + $"({arg.MacroVariableName},\"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.ByteArray:
-                        traceloggingLine += ",\\\n    TraceLoggingUInt8Array" + $"({arg.MacroVariableName}, {arg.MacroVariableName}_len, \"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingUInt8Array" + $"({arg.MacroVariableName}, {arg.MacroVariableName}_len, \"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.ANSI_String:
-                        traceloggingLine += ",\\\n    TraceLoggingString" + $"((const char *)({arg.MacroVariableName}),\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingString" + $"((const char *)({arg.MacroVariableName}),\"{arg.MacroVariableName}\")";
                         break;
 
                     case CLogEncodingType.UNICODE_String:
-                        traceloggingLine += ",\\\n    TraceLoggingWideString" + $"({arg.MacroVariableName},\"{arg.VariableInfo.SuggestedTelemetryName}\")";
+                        traceloggingLine += ",\\\n    TraceLoggingWideString" + $"({arg.MacroVariableName},\"{arg.MacroVariableName}\")";
                         break;
                 }
             }

--- a/src/clog/clog.csproj
+++ b/src/clog/clog.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.1.9</Version>
+    <Version>0.2.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>../nupkg</PackageOutputPath>

--- a/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
+++ b/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.1.9</Version>
+    <Version>0.2.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>../../nupkg</PackageOutputPath>

--- a/src/clog2text/clog2text_windows/Program.cs
+++ b/src/clog2text/clog2text_windows/Program.cs
@@ -180,7 +180,7 @@ namespace clog2text_windows
                                                 continue;
                                         }
 
-                                        string lookupArgName = argMap[arg.VariableInfo.SuggestedTelemetryName];
+                                        string lookupArgName = argMap[arg.MacroVariableName];
 
                                         if (!args.ContainsKey(lookupArgName))
                                         {
@@ -194,7 +194,7 @@ namespace clog2text_windows
                                             throw new Exception("InvalidType : " + node.DefinationEncoding);
                                         }
 
-                                        fixedUpArgs[arg.VariableInfo.SuggestedTelemetryName] = args[lookupArgName];
+                                        fixedUpArgs[arg.MacroVariableName] = args[lookupArgName];
                                         ++argIndex;
                                     }
 

--- a/src/clog2text/clog2text_windows/clog2text_windows.csproj
+++ b/src/clog2text/clog2text_windows/clog2text_windows.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.1.9</Version>
+    <Version>0.2.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>../../nupkg</PackageOutputPath>

--- a/src/clogutils/CLogConsoleTrace.cs
+++ b/src/clogutils/CLogConsoleTrace.cs
@@ -160,9 +160,9 @@ namespace clogutils
 
                         CLogEncodingCLogTypeSearch payload = type.TypeNode;
 
-                        if (!valueBag.TryGetValue(arg.VariableInfo.SuggestedTelemetryName, out IClogEventArg value))
+                        if (!valueBag.TryGetValue(arg.MacroVariableName, out IClogEventArg value))
                         {
-                            toPrint.Append($"<SKIPPED:BUG:MISSINGARG:{arg.VariableInfo.SuggestedTelemetryName}:{payload.EncodingType}>");
+                            toPrint.Append($"<SKIPPED:BUG:MISSINGARG:{arg.MacroVariableName}:{payload.EncodingType}>");
                         }
                         else
                         {

--- a/src/clogutils/CLogFileProcessor.cs
+++ b/src/clogutils/CLogFileProcessor.cs
@@ -278,7 +278,7 @@ namespace clogutils
                 }
 
                 CLogTypeContainer item = types.Dequeue();
-                finalArgs.Add(CLogVariableBundle.X(VariableInfo.X(splitArgs[i], vars[i].Item2), item.TypeNode.DefinationEncoding));
+                finalArgs.Add(CLogVariableBundle.X(splitArgs[i], vars[i].Item2, item.TypeNode.DefinationEncoding));
             }
 
             if (0 != types.Count)
@@ -380,29 +380,6 @@ namespace clogutils
             return contents;
         }
 
-        public class VariableInfo
-        {
-            public string UserSuppliedTrimmed { get; set; }
-
-            public string SuggestedTelemetryName { get; set; }
-
-            public static VariableInfo X(string user, string suggestedName)
-            {
-                foreach (char c in suggestedName)
-                {
-                    if (!char.IsLetter(c) && !char.IsNumber(c))
-                    {
-                        throw new Exception($"VariableName isnt valid {suggestedName}");
-                    }
-                }
-
-                VariableInfo v = new VariableInfo();
-                v.UserSuppliedTrimmed = user.Trim();
-                v.SuggestedTelemetryName = suggestedName;
-                return v;
-            }
-        }
-
         public class CLogTypeContainer
         {
             public string LeadingString { get; set; }
@@ -417,17 +394,19 @@ namespace clogutils
         [JsonObject(MemberSerialization.OptIn)]
         public class CLogVariableBundle
         {
-            [JsonProperty] public VariableInfo VariableInfo { get; set; }
 
             [JsonProperty] public string DefinationEncoding { get; set; }
 
             [JsonProperty] public string MacroVariableName { get; set; }
 
-            public static CLogVariableBundle X(VariableInfo i, string definationEncoding)
+            [JsonIgnore] public string UserSuppliedTrimmed { get; set; }
+
+            public static CLogVariableBundle X(string userString, string suggestedName, string definationEncoding)
             {
                 CLogVariableBundle b = new CLogVariableBundle();
-                b.VariableInfo = i;
+                b.MacroVariableName = suggestedName;
                 b.DefinationEncoding = definationEncoding;
+                b.UserSuppliedTrimmed = userString.Trim();
                 return b;
             }
         }

--- a/src/clogutils/CLogFullyDecodedMacroEmitter.cs
+++ b/src/clogutils/CLogFullyDecodedMacroEmitter.cs
@@ -77,7 +77,7 @@ namespace clogutils
                         clogArgCountForMacroAlignment += 2;
 
                         // Verify the input argument contains CLOG_BYTEARRAY - this will aid in debugging
-                        if (!arg.VariableInfo.UserSuppliedTrimmed.Contains("CLOG_BYTEARRAY"))
+                        if (!arg.UserSuppliedTrimmed.Contains("CLOG_BYTEARRAY"))
                         {
                             CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, $"Trace ID '{decodedTraceLine.UniqueId}' contains a ByteArray type that is not using the CLOG_BYTEARRAY macro");
                             CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, "    Please encode the following argument with CLOG_BYTEARRAY(length, pointer)");
@@ -85,7 +85,7 @@ namespace clogutils
                             CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, $"// {decodedTraceLine.match.MatchedRegEx}");
                             CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, "");
                             CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, $"Failing Arg: ");
-                            CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, arg.VariableInfo.UserSuppliedTrimmed);
+                            CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, arg.UserSuppliedTrimmed);
                             throw new CLogEnterReadOnlyModeException("ByteArrayNotUsingCLOG_BYTEARRAY", CLogHandledException.ExceptionType.ByteArrayMustUseMacro, decodedTraceLine.match);
                         }
                         break;
@@ -121,16 +121,14 @@ namespace clogutils
 
                     if (!v.Synthesized)
                     {
-                        implSignature += $", {v.CType} {arg.VariableInfo.SuggestedTelemetryName}";
-                        argsString += $", {arg.VariableInfo.SuggestedTelemetryName}";
+                        implSignature += $", {v.CType} {arg.MacroVariableName}";
+                        argsString += $", {arg.MacroVariableName}";
 
                         if (v.EncodingType == CLogEncodingType.ByteArray)
                         {
-                            implSignature += $", int {arg.VariableInfo.SuggestedTelemetryName}_len";
-                            argsString += $", {arg.VariableInfo.SuggestedTelemetryName}_len";
+                            implSignature += $", int {arg.MacroVariableName}_len";
+                            argsString += $", {arg.MacroVariableName}_len";
                         }
-
-                        arg.MacroVariableName = $"{arg.VariableInfo.SuggestedTelemetryName}";
                     }
                 }
 
@@ -159,7 +157,7 @@ namespace clogutils
 
             foreach (var arg in decodedTraceLine.splitArgs)
             {
-                _headerFile.AppendLine($"// {arg.MacroVariableName} = {arg.VariableInfo.SuggestedTelemetryName} = {arg.VariableInfo.UserSuppliedTrimmed}");
+                _headerFile.AppendLine($"// {arg.MacroVariableName} = {arg.MacroVariableName} = {arg.UserSuppliedTrimmed}");
             }
 
             _headerFile.AppendLine("----------------------------------------------------------*/");

--- a/src/converters/syslog2clog/syslog2clog.cs
+++ b/src/converters/syslog2clog/syslog2clog.cs
@@ -67,7 +67,7 @@ namespace syslog2clog
 
             foreach (var arg in decodedTraceLine.splitArgs)
             {
-                results.Append($", {arg.VariableInfo.UserSuppliedTrimmed}");
+                results.Append($", {arg.UserSuppliedTrimmed}");
             }
             results.Append(");");
         }


### PR DESCRIPTION
It makes changes difficult, as changing how a parameter is passed changes the sidecar, even if it can be decoded in the same way.

Closes #41 