### PR TITLE
Remove macro definition from traceline definition in sidecar

### DIFF
--- a/src/clogutils/CLogDecodedTraceLine.cs
+++ b/src/clogutils/CLogDecodedTraceLine.cs
@@ -56,9 +56,9 @@ namespace clogutils
         private CLogTraceMacroDefination macroStore;
 
         [JsonIgnore]
-        public CLogTraceMacroDefination macro 
+        public CLogTraceMacroDefination macro
         {
-            get 
+            get
             {
                 if (macroStore is null)
                 {

--- a/src/clogutils/CLogFileProcessor.cs
+++ b/src/clogutils/CLogFileProcessor.cs
@@ -295,7 +295,7 @@ namespace clogutils
                 throw new CLogEnterReadOnlyModeException("InvalidUniqueID", CLogHandledException.ExceptionType.InvalidUniqueId, traceLineMatch);
             }
 
-            CLogDecodedTraceLine decodedTraceLine = new CLogDecodedTraceLine(uniqueId, sourcefile, userArgs, splitArgs[macroDefination.EncodedArgNumber].Trim(), traceLineMatch, configFile, macroDefination, finalArgs.ToArray());
+            CLogDecodedTraceLine decodedTraceLine = new CLogDecodedTraceLine(uniqueId, sourcefile, userArgs, splitArgs[macroDefination.EncodedArgNumber].Trim(), traceLineMatch, configFile, macroDefination.MacroName, finalArgs.ToArray());
 
             return decodedTraceLine;
         }


### PR DESCRIPTION
It was duplicated hundreds of times throughout the file, when the file already contained the configuration for each macro. Instead of storing the entire macro definition, just store the macro name. This can then be used to look up the definition.

Closes #42 