### PR TITLE
Remove NUGET package generation

### DIFF
--- a/src/clog/clog.csproj
+++ b/src/clog/clog.csproj
@@ -23,23 +23,6 @@
     <ProjectReference Include="..\clogutils\clogutils.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <Version>0.3.1</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackAsTool>true</PackAsTool>
-    <PackageOutputPath>../nupkg</PackageOutputPath>
-    <ToolCommandName>clog</ToolCommandName>
-    <PackageId>Microsoft.Logging.CLOG</PackageId>
-    <Authors>Microsoft</Authors>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>© Microsoft Corporation. All rights reserved</Copyright>
-    <Title>CLOG Log Generator</Title>
-    <ProjectURL>https://github.com/microsoft/CLOG</ProjectURL>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/microsoft/CLOG</RepositoryUrl>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
     <OutputPath></OutputPath>
   </PropertyGroup>

--- a/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
+++ b/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
@@ -19,21 +19,4 @@
     <ProjectReference Include="..\..\clogutils\clogutils.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <Version>0.3.0</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackAsTool>true</PackAsTool>
-    <PackageOutputPath>../../nupkg</PackageOutputPath>
-    <ToolCommandName>clog2text_lttng</ToolCommandName>
-    <PackageId>Microsoft.Logging.CLOG2Text.Lttng</PackageId>
-    <Authors>Microsoft</Authors>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>© Microsoft Corporation. All rights reserved</Copyright>
-    <Title>CLOG Lttng log converter</Title>
-    <ProjectURL>https://github.com/microsoft/CLOG</ProjectURL>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/microsoft/CLOG</RepositoryUrl>
-  </PropertyGroup>
-
 </Project>

--- a/src/clog2text/clog2text_windows/clog2text_windows.csproj
+++ b/src/clog2text/clog2text_windows/clog2text_windows.csproj
@@ -20,21 +20,4 @@
     <ProjectReference Include="..\..\clogutils\clogutils.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <Version>0.3.0</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackAsTool>true</PackAsTool>
-    <PackageOutputPath>../../nupkg</PackageOutputPath>
-    <ToolCommandName>clog2text_windows</ToolCommandName>
-    <PackageId>Microsoft.Logging.CLOG2Text.Windows</PackageId>
-    <Authors>Microsoft</Authors>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>© Microsoft Corporation. All rights reserved</Copyright>
-    <Title>CLOG Lttng log converter</Title>
-    <ProjectURL>https://github.com/microsoft/CLOG</ProjectURL>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/microsoft/CLOG</RepositoryUrl>
-  </PropertyGroup>
-
 </Project>

--- a/src/converters/syslog2clog/syslog2clog.csproj
+++ b/src/converters/syslog2clog/syslog2clog.csproj
@@ -13,12 +13,10 @@
     <NoWarn>1701;1702;3026</NoWarn>
   </PropertyGroup>
 
-
  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
-
 
  <ItemGroup>
    <ProjectReference Include="..\..\clogutils\clogutils.csproj" />


### PR DESCRIPTION
instead, favor users building CLOG themselves - the dotnet installers have improved and it's easier to get the dotnet dependencies than to get the clog dependencies