### PR TITLE
Fix problem with STDIO output of a string that doesnt contain any variables

### DIFF
--- a/.github/workflows/check-clog-linux.yml
+++ b/.github/workflows/check-clog-linux.yml
@@ -1,4 +1,4 @@
-name: LINUX_TEST_BUILD
+name: LINUX_TEST_BUILD_LTTNG
 
 on:
   push:

--- a/.github/workflows/check-clog-windows.yml
+++ b/.github/workflows/check-clog-windows.yml
@@ -1,4 +1,4 @@
-name: WINDOWS_TEST_BUILD
+name: WINDOWS_TEST_BUILD_ETW
 
 on:
   push:

--- a/examples/clog.sidecar
+++ b/examples/clog.sidecar
@@ -186,6 +186,13 @@
         }
       ],
       "macroName": "TraceInfo"
+    },
+    "NO_ARGS": {
+      "ModuleProperites": {},
+      "TraceString": "9. This trace has no args",
+      "UniqueId": "NO_ARGS",
+      "splitArgs": [],
+      "macroName": "TraceError"
     }
   },
   "ConfigFile": {
@@ -598,6 +605,11 @@
         "UniquenessHash": "00e55ab5-2581-5789-25d5-069f2b00c9bb",
         "TraceID": "DATA_NAMED_INT",
         "EncodingString": "5. This is a named int: %{myInt,d};  it should be 1234"
+      },
+      {
+        "UniquenessHash": "047bd97d-e78c-6e56-2f56-512c2382056e",
+        "TraceID": "NO_ARGS",
+        "EncodingString": "9. This trace has no args"
       }
     ]
   }

--- a/examples/clogsample/simple.cpp
+++ b/examples/clogsample/simple.cpp
@@ -59,6 +59,9 @@ int main(int argc, char* argv[])
     TraceError(INT_ERROR, "7. this is an error %d", 123456);
     TraceError(INT_ERROR_2, "8. this is an error %d with a string %s", 80, "ouch!");
 
+    TraceError(NO_ARGS, "9. This trace has no args");
+
+
     #ifdef CLOG_ETW
         EventUnregisterCLOG_SAMPLE_MANIFEST();
         TraceLoggingUnregister(clog_hTrace);

--- a/examples/runTests.ps1
+++ b/examples/runTests.ps1
@@ -48,8 +48,8 @@ if($IsWindows) {
     dir
 
     wevtutil.exe um clog_examples.man
-
     wevtutil.exe im clog_examples.man
+
     if(!$?) {
         Write-Host "Manifest registration failed"
         Exit -5

--- a/examples/runTests.ps1
+++ b/examples/runTests.ps1
@@ -17,27 +17,27 @@ if ($IsLinux) {
     if(!$?)
     {
         Write-Host "LTTNG Create failed"
-        Exit
+        Exit -1
     }
 
     lttng enable-event --userspace CLOG_*
     if(!$?)
     {
         Write-Host "LTTNG enable-event failed"
-        Exit
+        Exit -2
     }
 
     lttng add-context --userspace --type=vpid --type=vtid
     if(!$?)
     {
         Write-Host "LTTNG add-context failed"
-        Exit
+        Exit -3
     }
     lttng start
     if(!$?)
     {
         Write-Host "LTTNG start failed"
-        Exit
+        Exit -4
     }
 }
 
@@ -45,12 +45,14 @@ if($IsWindows) {
     move .\clogsample\Debug\* .\clogsample -Force
 
     cd .\clogsample
+    dir
+
     wevtutil.exe um clog_examples.man
 
     wevtutil.exe im clog_examples.man
     if(!$?) {
         Write-Host "Manifest registration failed"
-        Exit
+        Exit -5
     } else {
         Write-Host "ETW Manifest installed"
     }
@@ -60,7 +62,7 @@ if($IsWindows) {
     if(!$?)
     {
         Write-Host "WPR wouldnt start"
-        Exit
+        Exit -6
     }
 
     cd ..
@@ -70,7 +72,7 @@ if($IsWindows) {
 if(!$?)
 {
     Write-Host "Unable to run test"
-    Exit
+    Exit -7
 }
 
 if ($IsLinux) {
@@ -94,7 +96,7 @@ if ($IsWindows)
     if(!$?)
     {
         Write-Host "WPR stop failed"
-        Exit
+        Exit -8
     }
 
     cd ..
@@ -121,7 +123,7 @@ if($diffs.Length -ne 0)
     Compare-Object (Get-Content ./test.output.txt) (Get-Content ../test.desired.output.txt)
 
     cd ..
-    Exit -1
+    Exit -9
 }
 else
 {

--- a/examples/test.desired.output.basic.txt
+++ b/examples/test.desired.output.basic.txt
@@ -6,3 +6,4 @@
 6. This is an int: 1234;  it should be 1234
 7. this is an error 123456
 8. this is an error 80 with a string ouch!
+9. This trace has no args

--- a/examples/test.desired.output.txt
+++ b/examples/test.desired.output.txt
@@ -6,3 +6,4 @@
 6. This is an int: 1234;  it should be 1234
 7. this is an error 123456
 8. this is an error 80 with a string ouch!
+9. This trace has no args

--- a/src/clog/CommandLineArguments.cs
+++ b/src/clog/CommandLineArguments.cs
@@ -193,7 +193,10 @@ namespace clog
             {
                 if (string.IsNullOrEmpty(this.ConfigurationProfile))
                 {
-                    CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, "Please specify both the side car to update, and the configuration file that contains a reference to the new type processor");
+                    CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, $"Please verify the sidecar, configuration file, and profile are all correct");
+                    CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, $"    SideCar: {this.SidecarFile}");
+                    CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, $"    Configuration File: {this.ConfigurationFile}");
+                    CLogConsoleTrace.TraceLine(CLogConsoleTrace.TraceType.Err, $"    Configuration Profile: {this.ConfigurationProfile}");
                     return false;
                 }
             }

--- a/src/clog/TraceEmitterModules/CLogSTDOUT.cs
+++ b/src/clog/TraceEmitterModules/CLogSTDOUT.cs
@@ -157,11 +157,17 @@ namespace clog.TraceEmitterModules
                 }
             }
 
-            // Print the remainder of user text
+            //
+            // Print the remainder of user text (the tail end);  if there are no types at all then 'TraceString' is just a constant string
+            //
             if (types.Length >= 1)
             {
                 string tail = decodedTraceLine.TraceString.Substring(types[types.Length - 1].ArgStartingIndex + types[types.Length - 1].ArgLength);
                 printf += tail;
+            }
+            else
+            {
+                printf += decodedTraceLine.TraceString;
             }
 
             printf += "\\n";


### PR DESCRIPTION
Should an event be produced without any args, the printf() (STDIO) output is empty - fixing that in the STDIO emittor

