### PR TITLE
sort sidecar, this makes diffing easier

### DIFF
--- a/src/clog2text/clog2text_windows/Program.cs
+++ b/src/clog2text/clog2text_windows/Program.cs
@@ -101,7 +101,7 @@ namespace clog2text_windows
 
                                         foreach (var b in sidecar.EventBundlesV2)
                                         {
-                                            Dictionary<string, string> keys;
+                                            SortedDictionary<string, string> keys;
 
                                             if (!e.IsTraceLogging)
                                             {

--- a/src/clogutils/CLogDecodedTraceLine.cs
+++ b/src/clogutils/CLogDecodedTraceLine.cs
@@ -20,7 +20,7 @@ namespace clogutils
     [JsonObject(MemberSerialization.OptIn)]
     public class CLogDecodedTraceLine
     {
-        [JsonProperty] public Dictionary<string, Dictionary<string, string>> ModuleProperites = new Dictionary<string, Dictionary<string, string>>();
+        [JsonProperty] public SortedDictionary<string, SortedDictionary<string, string>> ModuleProperites = new SortedDictionary<string, SortedDictionary<string, string>>();
 
         public CLogDecodedTraceLine(string uniqueId, string sourceFile, string userString, string userStringNoPrefix, CLogLineMatch m, CLogConfigurationFile c,
             CLogTraceMacroDefination mac, CLogFileProcessor.CLogVariableBundle[] args, CLogFileProcessor.DecomposedString decompString)
@@ -142,7 +142,7 @@ namespace clogutils
 
             if (!ModuleProperites.ContainsKey(module))
             {
-                ModuleProperites[module] = new Dictionary<string, string>();
+                ModuleProperites[module] = new SortedDictionary<string, string>();
             }
 
             ModuleProperites[module][key] = value;

--- a/src/clogutils/CLogEncodingCLogTypeSearch.cs
+++ b/src/clogutils/CLogEncodingCLogTypeSearch.cs
@@ -42,7 +42,7 @@ namespace clogutils
         {
             get
             {
-                return !Synthesized && 
+                return !Synthesized &&
                         (EncodingType != CLogEncodingType.UniqueAndDurableIdentifier &&
                         EncodingType != CLogEncodingType.UserEncodingString);
             }

--- a/src/clogutils/CLogSidecar.cs
+++ b/src/clogutils/CLogSidecar.cs
@@ -25,7 +25,7 @@ namespace clogutils
         [JsonProperty] public int Version { get; set; }
 
         [JsonProperty]
-        public Dictionary<string, CLogDecodedTraceLine> EventBundlesV2 { get; set; } = new Dictionary<string, CLogDecodedTraceLine>();
+        public SortedDictionary<string, CLogDecodedTraceLine> EventBundlesV2 { get; set; } = new SortedDictionary<string, CLogDecodedTraceLine>();
 
         [JsonProperty] public CLogConfigurationFile ConfigFile { get; set; }
 
@@ -67,7 +67,7 @@ namespace clogutils
         [JsonProperty] public int Version { get; set; }
 
         [JsonProperty]
-        public Dictionary<string, CLogDecodedTraceLine> EventBundlesV2 { get; set; } = new Dictionary<string, CLogDecodedTraceLine>();
+        public SortedDictionary<string, CLogDecodedTraceLine> EventBundlesV2 { get; set; } = new SortedDictionary<string, CLogDecodedTraceLine>();
 
         [JsonProperty] public CLogConfigurationFile ConfigFile { get; set; }
 
@@ -85,6 +85,8 @@ namespace clogutils
 
         public string ToJson()
         {
+            ModuleUniqueness.Sort();
+
             JsonSerializerSettings s = new JsonSerializerSettings();
             s.Formatting = Formatting.Indented;
             this.Version = 2;
@@ -126,7 +128,7 @@ namespace clogutils
     {
         private string _sidecarFileName;
 
-        private Dictionary<string, Dictionary<string, Dictionary<string, string>>> ModuleTraceData = new Dictionary<string, Dictionary<string, Dictionary<string, string>>>();
+        private SortedDictionary<string, Dictionary<string, Dictionary<string, string>>> ModuleTraceData = new SortedDictionary<string, Dictionary<string, Dictionary<string, string>>>();
 
         private ClogSidecar_V2 _sideCarFile;
 

--- a/src/clogutils/ConfigFile/CLogModuleUsageInformation.cs
+++ b/src/clogutils/ConfigFile/CLogModuleUsageInformation.cs
@@ -36,6 +36,11 @@ namespace clogutils.ConfigFile
             }
             return ret;
         }
+
+        public void Sort()
+        {
+            TraceInformation.Sort((a, b) => a.TraceID.CompareTo(b.TraceID));
+        }
     }
 
 


### PR DESCRIPTION
Having a sorted sidecar helps when adding new events - specifically in the diffing process

in this change, most of the sidecar is sorted