### PR TITLE
Package clog conversion tools into nuget dotnet tools

### DIFF
--- a/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
+++ b/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
@@ -19,4 +19,21 @@
     <ProjectReference Include="..\..\clogutils\clogutils.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <Version>0.0.1</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackAsTool>true</PackAsTool>
+    <PackageOutputPath>../../nupkg</PackageOutputPath>
+    <ToolCommandName>clog2text_lttng</ToolCommandName>
+    <PackageId>Microsoft.Logging.CLOG2Text.Lttng</PackageId>
+    <Authors>Microsoft</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>© Microsoft Corporation. All rights reserved</Copyright>
+    <Title>CLOG Lttng log converter</Title>
+    <ProjectURL>https://github.com/microsoft/CLOG</ProjectURL>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/microsoft/CLOG</RepositoryUrl>
+  </PropertyGroup>
+
 </Project>

--- a/src/clog2text/clog2text_windows/clog2text_windows.csproj
+++ b/src/clog2text/clog2text_windows/clog2text_windows.csproj
@@ -20,4 +20,22 @@
     <ProjectReference Include="..\..\clogutils\clogutils.csproj" />
   </ItemGroup>
 
+
+  <PropertyGroup>
+    <Version>0.0.1</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackAsTool>true</PackAsTool>
+    <PackageOutputPath>../../nupkg</PackageOutputPath>
+    <ToolCommandName>clog2text_windows</ToolCommandName>
+    <PackageId>Microsoft.Logging.CLOG2Text.Windows</PackageId>
+    <Authors>Microsoft</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>© Microsoft Corporation. All rights reserved</Copyright>
+    <Title>CLOG Windows log converter</Title>
+    <ProjectURL>https://github.com/microsoft/CLOG</ProjectURL>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/microsoft/CLOG</RepositoryUrl>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
To solve https://github.com/microsoft/msquic/issues/2456 I need some way to move clog2text from a build stage to a test run stage. The easiest way to do so is to publish as a .NET tool. Unlike previous attempts, this package will NOT be published outside of the build, and will instead just be used as part of the internal pipeline.