### PR TITLE
Bump Newtonsoft.Json from 12.0.3 to 13.0.1

### DIFF
--- a/src/clog/clog.csproj
+++ b/src/clog/clog.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
+++ b/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/clogutils/clogutils.csproj
+++ b/src/clogutils/clogutils.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Basic.Reference.Assemblies" Version="1.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0" />
     <PackageReference Include="System.CodeDom" Version="4.7.0" />

--- a/src/converters/syslog2clog/syslog2clog.csproj
+++ b/src/converters/syslog2clog/syslog2clog.csproj
@@ -15,7 +15,7 @@
 
  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
  <ItemGroup>


### PR DESCRIPTION
Dependabot only did it one at a time, which seemed to cause build issues.