### PR TITLE
Add dependency on clog executable for custom command

### DIFF
--- a/defaults/CLog.cmake
+++ b/defaults/CLog.cmake
@@ -41,6 +41,7 @@ function(CLOG_GENERATE_TARGET)
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${arg}
             DEPENDS ${CMAKE_CLOG_CONFIG_FILE}
             DEPENDS ${CMAKE_CLOG_EXTRA_DEPENDENCIES}
+            DEPENDS ${CLOG_EXE}
             COMMENT "CLOG: clog --readOnly ${ARG_CLOG_DYNAMIC_TRACEPOINT} -p ${CMAKE_CLOG_CONFIG_PROFILE} --scopePrefix ${library} -c ${CMAKE_CLOG_CONFIG_FILE} -s ${CMAKE_CLOG_SIDECAR_DIRECTORY}/clog.sidecar --inputFiles ${CMAKE_CURRENT_SOURCE_DIR}/${arg} --outputDirectory ${ARG_CLOG_OUTPUT_DIR}"
             COMMAND ${CLOG_EXE} --readOnly ${ARG_CLOG_DYNAMIC_TRACEPOINT} -p ${CMAKE_CLOG_CONFIG_PROFILE} --scopePrefix ${library} -c ${CMAKE_CLOG_CONFIG_FILE} -s ${CMAKE_CLOG_SIDECAR_DIRECTORY}/clog.sidecar --inputFiles ${CMAKE_CURRENT_SOURCE_DIR}/${arg} --outputDirectory ${ARG_CLOG_OUTPUT_DIR}
         )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,7 +4,7 @@ project (clogexamples)
 add_subdirectory(.. buildclog)
 
 LIST(APPEND CMAKE_PROGRAM_PATH  "${PROJECT_BINARY_DIR}/buildclog/artifacts")
-set(CLOG_EXE  "${PROJECT_BINARY_DIR}/buildclog/artifacts/clog")
+set(CLOG_EXE  "${PROJECT_BINARY_DIR}/buildclog/artifacts/clog${CMAKE_EXECUTABLE_SUFFIX}")
 
 set(CMAKE_CLOG_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bld/clog)
 set(CMAKE_CLOG_SIDECAR_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
The custom command which run clog tool missed dependency on the clog executable itself which could trigger below error during multiple tasked build.

```console
C:\CLOG\examples\out> ninja
[1/11] CLOG: clog --readOnly  -p windows --scopePrefix CLOGSAMPLE_LIB -c C:/CLOG/examples/clog_examp...C:/GH/CLOG/examples/clogsample/simple.cpp --outputDirectory C:/CLOG/examples/bld/clog/CLOGSAMPLE_LIB
FAILED: ../bld/clog/CLOGSAMPLE_LIB/simple.cpp.clog.h ../bld/clog/CLOGSAMPLE_LIB/CLOGSAMPLE_LIB_simple.cpp.clog.h.c C:/CLOG/examples/bld/clog/CLOGSAMPLE_LIB/simple.cpp.clog.h C:/CLOG/examples/bld/clog/CLOGSAMPLE_LIB/CLOGSAMPLE_LIB_simple.cpp.clog.h.c
cmd.exe /C "cd /D C:\CLOG\examples\out\clogsample && C:\CLOG\examples\out\buildclog\artifacts\clog.exe --readOnly -p windows --scopePrefix CLOGSAMPLE_LIB -c C:/CLOG/examples/clog_examples.clog_config -s C:/CLOG/examples/clog.sidecar --inputFiles C:/CLOG/examples/clogsample/simple.cpp --outputDirectory C:/CLOG/examples/bld/clog/CLOGSAMPLE_LIB"
'C:\CLOG\examples\out\buildclog\artifacts\clog.exe' is not recognized as an internal or external command,
operable program or batch file.
```