### PR TITLE
Disable nuget central package management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
We're [trying](https://github.com/microsoft/msquic/pull/5229) to convert MsQuic to use [central package management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) but a CI job running CLOG is failing with

```
D:\a\msquic\msquic\submodules\clog\src\clogutils\clogutils.csproj : error NU1008: Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: Microsoft.CodeAnalysis.CSharp;Newtonsoft.Json;Basic.Reference.Assemblies;Microsoft.CodeAnalysis;System.CodeDom. [D:\a\msquic\msquic\submodules\clog\src\clog\clog.csproj]
D:\a\msquic\msquic\submodules\clog\src\clog\clog.csproj : error NU1008: Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion items: CommandLineParser;Newtonsoft.Json.
  Failed to restore D:\a\msquic\msquic\submodules\clog\src\clog\clog.csproj (in 143 ms).
  Failed to restore D:\a\msquic\msquic\submodules\clog\src\clogutils\clogutils.csproj (in 140 ms).
```

For now, explicitly disable CPM in CLOG.