### PR TITLE
Fix Linux CI - remove obsolete PPA

### DIFF
--- a/.github/workflows/check-clog-linux.yml
+++ b/.github/workflows/check-clog-linux.yml
@@ -24,7 +24,6 @@ jobs:
         dotnet-version: 6.0.x
 
     - run: |
-         sudo apt-add-repository ppa:lttng/stable-2.12
          sudo apt-get update
          sudo apt-get install -y liblttng-ust-dev lttng-tools build-essential
 


### PR DESCRIPTION
We're getting CI failures related to the 2.12 PPA. Since `ubuntu-latest` has good enough lttng packages in its default sources, use those.