### PR TITLE
Update to .NET 8.0

### DIFF
--- a/.github/workflows/check-clog-linux-printf.yml
+++ b/.github/workflows/check-clog-linux-printf.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Build CLOG and run Tests
       run: ./runTests_stdio.ps1

--- a/.github/workflows/check-clog-linux.yml
+++ b/.github/workflows/check-clog-linux.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - run: |
          sudo apt-get update

--- a/.github/workflows/check-clog-windows-printf.yml
+++ b/.github/workflows/check-clog-windows-printf.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Build CLOG and run Tests
       run: ./runTests_stdio.ps1

--- a/.github/workflows/check-clog-windows.yml
+++ b/.github/workflows/check-clog-windows.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Build CLOG and run Tests
       run: ./runTests.ps1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -7,7 +7,5 @@ cmake -G "Unix Makefiles" ..
 
 cmake -G "Visual Studio 16 2019" -A x64 ..
 
-dotnet publish ./src/clog/clog.csproj --self-contained -o /home/chgray/.dotnet/tools -f net6.0 -r win-x64
-dotnet publish ./src/clog/clog.csproj --self-contained -o /home/chgray/.dotnet/tools -f net6.0 -r linux-x64 -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true
-
-https://github.com/chgray/msquic/blob/53198319bd1460a04823eb6859b776b964f145f6/docs/BUILD.md
+dotnet publish ./src/clog/clog.csproj --self-contained -o /home/chgray/.dotnet/tools -f net8.0 -r win-x64
+dotnet publish ./src/clog/clog.csproj --self-contained -o /home/chgray/.dotnet/tools -f net8.0 -r linux-x64 -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true

--- a/src/clog/CMakeLists.txt
+++ b/src/clog/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SOURCES
     clog.cs
     CommandLineArguments.cs)
 
-DOT_NET_BUILD(CLOG_EXE clog.exe ${CMAKE_CURRENT_SOURCE_DIR}/clog.csproj net6.0 ${SOURCES})
+DOT_NET_BUILD(CLOG_EXE clog.exe ${CMAKE_CURRENT_SOURCE_DIR}/clog.csproj net8.0 ${SOURCES})

--- a/src/clog/clog.cs
+++ b/src/clog/clog.cs
@@ -5,9 +5,9 @@
 
 Abstract:
 
-    This class implements the main configuration and setup for reading clog config files, your source code, side cars etc.
+    This class implements the main configuration and setup for reading Clog config files, your source code, side cars etc.
 
-    By implementing the main() for clog, it's mostly connecting up other clases
+    By implementing the main() for Clog, it's mostly connecting up other clases
 
 --*/
 
@@ -22,7 +22,7 @@ using CommandLine;
 
 namespace clog
 {
-    internal class clog
+    internal class Clog
     {
         private static int Main(string[] args)
         {

--- a/src/clog/clog.csproj
+++ b/src/clog/clog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\clogutils\clogutils.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
     <OutputPath></OutputPath>
   </PropertyGroup>
 

--- a/src/clog/clog.csproj
+++ b/src/clog/clog.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/clog2text/clog2text_lttng/CMakeLists.txt
+++ b/src/clog2text/clog2text_lttng/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
     Program.cs)
 
 
-DOT_NET_BUILD(CLOG2TEXT_LTTNG clog2text_lttng.exe ${CMAKE_CURRENT_SOURCE_DIR}/clog2text_lttng.csproj net6.0 ${SOURCES})
+DOT_NET_BUILD(CLOG2TEXT_LTTNG clog2text_lttng.exe ${CMAKE_CURRENT_SOURCE_DIR}/clog2text_lttng.csproj net8.0 ${SOURCES})

--- a/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
+++ b/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
+++ b/src/clog2text/clog2text_lttng/clog2text_lttng.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/clog2text/clog2text_windows/CMakeLists.txt
+++ b/src/clog2text/clog2text_windows/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
     Program.cs)
 
 
-DOT_NET_BUILD(CLOG2TEXT_WINDOWS clog2text_windows.exe ${CMAKE_CURRENT_SOURCE_DIR}/clog2text_windows.csproj net6.0 ${SOURCES})
+DOT_NET_BUILD(CLOG2TEXT_WINDOWS clog2text_windows.exe ${CMAKE_CURRENT_SOURCE_DIR}/clog2text_windows.csproj net8.0 ${SOURCES})

--- a/src/clog2text/clog2text_windows/clog2text_windows.csproj
+++ b/src/clog2text/clog2text_windows/clog2text_windows.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/clog2text/clog2text_windows/clog2text_windows.csproj
+++ b/src/clog2text/clog2text_windows/clog2text_windows.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/clogutils/clogutils.csproj
+++ b/src/clogutils/clogutils.csproj
@@ -4,6 +4,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/converters/syslog2clog/syslog2clog.csproj
+++ b/src/converters/syslog2clog/syslog2clog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/converters/syslog2clog/syslog2clog.csproj
+++ b/src/converters/syslog2clog/syslog2clog.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/decoderTest/decoderTest.csproj
+++ b/src/decoderTest/decoderTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/decoderTest/decoderTest.csproj
+++ b/src/decoderTest/decoderTest.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Update to .NET 8.0 (current LTS version)

.NET 6.0 is out of support and can't be installed easily (at least on Ubuntu 24.04 LTS).

Closes #116